### PR TITLE
Fix socket timeouts which were causing jsonbot to drop/rejoin to irc

### DIFF
--- a/jsb/plugs/common/__init__.py
+++ b/jsb/plugs/common/__init__.py
@@ -8,9 +8,9 @@ import os
 
 (f, tail) = os.path.split(__file__)
 __all__ = []
-
+blocklist = ["twitter.py"]
 for i in os.listdir(f):
-    if i.endswith(".py"):
+    if i.endswith(".py") and i not in blocklist:
         __all__.append(i[:-3])
     elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
         __all__.append(i)

--- a/jsb/plugs/core/__init__.py
+++ b/jsb/plugs/core/__init__.py
@@ -8,9 +8,9 @@ import os
 
 (f, tail) = os.path.split(__file__)
 __all__ = []
-
+blocklist = ["remotecallbacks.py"]
 for i in os.listdir(f):
-    if i.endswith(".py"):
+    if i.endswith(".py") and i not in blocklist:
         __all__.append(i[:-3])
     elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
         __all__.append(i)

--- a/jsb/plugs/socket/__init__.py
+++ b/jsb/plugs/socket/__init__.py
@@ -8,9 +8,9 @@ import os
 
 (f, tail) = os.path.split(__file__)
 __all__ = []
-
+blocklist = ["fish.py", "irccat.py", "geo.py"]
 for i in os.listdir(f):
-    if i.endswith(".py"):
+    if i.endswith(".py") and i not in blocklist:
         __all__.append(i[:-3])
     elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
         __all__.append(i)

--- a/jsb/plugs/socket/irccat.py
+++ b/jsb/plugs/socket/irccat.py
@@ -24,8 +24,8 @@ unless you set up an alias in your channel:
 
 import logging
 import socketserver
-import time
 import sys
+import time
 import traceback
 from socketserver import StreamRequestHandler, ThreadingMixIn
 


### PR DESCRIPTION
Not sure what the root cause was but two things seem to make a
difference:

- setting TCP keepalive on a socket

- changing socket timeout to infinity.

My understanding is that the main reason for this fix to work is
pushing socket timeout past the IRC PING/PONG rate. Otherwise
readline() on socket times out beore we get a PING/PONG and we rejoin.

We also set tcp keepalive to ensure the server is still there, even
though higher layer never times out by default.


also

Don't load broken modules by default

These modules don't work properly so let's avoid a couple of
exceptions on start by not trying to load broken code.