### PR TITLE
Make print_exc python3.9 compatible

### DIFF
--- a/jsb/drivers/sleek/bot.py
+++ b/jsb/drivers/sleek/bot.py
@@ -73,14 +73,14 @@ class SleekBot(SXMPPBot):
         self.xmpp.send_presence()
         start_new_thread(self.joinchannels, ())
 
-    def exception(self, ex):
-        logging.error(traceback.format_exception(ex))
+    def exception(self, exc):
+        logging.error(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
     def handle_failedauth(self, error, *args):
         logging.error(error)
 
-    def handle_failure(self, ex, *args, **kwargs):
-        logging.error(traceback.format_exception(ex))
+    def handle_failure(self, exc, *args, **kwargs):
+        logging.error(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
     def handle_disconnected(self, *args, **kwargs):
         logging.error("server disconnected")
@@ -94,8 +94,8 @@ class SleekBot(SXMPPBot):
             if connect:
                 self.xmpp.connect()
             self.xmpp.process(block=True)
-        except Exception as ex:
-            logging.error(traceback.format_exception(ex))
+        except Exception as exc:
+            logging.error(traceback.format_exception(type(exc), exc, exc.__traceback__))
 
     def send(self, event):
         try:
@@ -219,5 +219,5 @@ class SleekBot(SXMPPBot):
                 except KeyError:
                     pass
             self.put(p)
-        except Exception as ex:
-            logging.error(traceback.format_exception(ex))
+        except Exception as exc:
+            logging.error(traceback.format_exception(type(exc), exc, exc.__traceback__))

--- a/jsb/lib/botbase.py
+++ b/jsb/lib/botbase.py
@@ -308,8 +308,10 @@ class BotBase(LazyDict):
                 if self.status != "start" and not self.pingcheck():
                     self.reconnect()
                     break
-            except Exception as ex:
-                logging.error(traceback.format_exception(ex))
+            except Exception as exc:
+                logging.error(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                )
                 self.reconnect()
                 break
             time.sleep(self.cfg.pingsleep or 60)
@@ -702,8 +704,10 @@ class BotBase(LazyDict):
                     self.exit(close=close)
                 if self.doreconnect():
                     break
-            except Exception as ex:
-                logging.error(traceback.format_exception(ex))
+            except Exception as exc:
+                logging.error(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                )
 
     def doreconnect(self, start=False):
         self.started = False

--- a/jsb/lib/eventbase.py
+++ b/jsb/lib/eventbase.py
@@ -156,8 +156,10 @@ class EventBase(LazyDict):
         else:
             try:
                 res = cmnds.dispatch(self.bot, self, direct=direct, *args, **kwargs)
-            except RequireError as ex:
-                logging.error(traceback.format_exception(ex))
+            except RequireError as exc:
+                logging.error(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                )
             except NoSuchCommand as ex:
                 logging.error("we don't have a %s command" % str(ex))
             except NoSuchUser as ex:

--- a/jsb/plugs/common/plus.py
+++ b/jsb/plugs/common/plus.py
@@ -92,8 +92,10 @@ def plusscan(skip=False):
                         bot.say(chan, "new plus update: ", todo)
                 else:
                     logging.warn("no %s bot in fleet" % botname)
-            except AttributeError as ex:
-                logging.error(traceback.format_exception(ex))
+            except AttributeError as exc:
+                logging.error(
+                    traceback.format_exception(type(exc), exc, exc.__traceback__)
+                )
             except Exception as ex:
                 handle_exception()
     state.save()

--- a/jsb/plugs/socket/irccat2.py
+++ b/jsb/plugs/socket/irccat2.py
@@ -130,8 +130,8 @@ def init_threaded():
         server = socketserver.TCPServer(
             (cfg["host"], int(cfg["iccatport"])), IrcCatListener
         )
-    except Exception as ex:
-        logging.error(traceback.format_exception(ex))
+    except Exception as exc:
+        logging.error(traceback.format_exception(type(exc), exc, exc.__traceback__))
         return
     logging.warn("starting irccat2 server on %s:%s" % (cfg["host"], cfg["iccatport"]))
     thr = start_new_thread(server.serve_forever, ())

--- a/jsb/plugs/socket/markov.py
+++ b/jsb/plugs/socket/markov.py
@@ -28,6 +28,7 @@ import os
 import random
 import re
 import time
+import traceback
 
 from jsb.lib.callbacks import callbacks
 from jsb.lib.commands import cmnds
@@ -282,8 +283,8 @@ def markovlearnurl(url):
                 continue
             markovtalk_learn(line)
             lines += 1
-    except Exception as e:
-        logging.error(traceback.format_exception(e))
+    except Exception as exc:
+        logging.error(traceback.format_exception(type(exc), exc, exc.__traceback__))
     logging.warn("learning %s done" % url)
     return lines
 


### PR DESCRIPTION
this should no longer make the program crash when handling exceptions on older pythons, as we fixed incorrect calls to handle_exception inside an exception handler.