### PR TITLE
Don't try loading modules from __pycache__ directories

### DIFF
--- a/jsb/data/__init__.py
+++ b/jsb/data/__init__.py
@@ -12,7 +12,7 @@ __all__ = []
 for i in os.listdir(f):
     if i.endswith(".py"):
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/data/myplugs/__init__.py
+++ b/jsb/data/myplugs/__init__.py
@@ -12,7 +12,7 @@ __all__ = []
 for i in os.listdir(f):
     if i.endswith(".py"):
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/data/myplugs/gae/__init__.py
+++ b/jsb/data/myplugs/gae/__init__.py
@@ -12,7 +12,7 @@ __all__ = []
 for i in os.listdir(f):
     if i.endswith(".py"):
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/data/myplugs/socket/__init__.py
+++ b/jsb/data/myplugs/socket/__init__.py
@@ -12,7 +12,7 @@ __all__ = []
 for i in os.listdir(f):
     if i.endswith(".py"):
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/plugs/common/__init__.py
+++ b/jsb/plugs/common/__init__.py
@@ -12,7 +12,7 @@ blocklist = ["twitter.py"]
 for i in os.listdir(f):
     if i.endswith(".py") and i not in blocklist:
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/plugs/core/__init__.py
+++ b/jsb/plugs/core/__init__.py
@@ -12,7 +12,7 @@ blocklist = ["remotecallbacks.py"]
 for i in os.listdir(f):
     if i.endswith(".py") and i not in blocklist:
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/plugs/db/__init__.py
+++ b/jsb/plugs/db/__init__.py
@@ -12,7 +12,7 @@ __all__ = []
 for i in os.listdir(f):
     if i.endswith(".py"):
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/plugs/myplugs/__init__.py
+++ b/jsb/plugs/myplugs/__init__.py
@@ -12,7 +12,7 @@ __all__ = []
 for i in os.listdir(f):
     if i.endswith(".py"):
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/plugs/myplugs/common/__init__.py
+++ b/jsb/plugs/myplugs/common/__init__.py
@@ -12,7 +12,7 @@ __all__ = []
 for i in os.listdir(f):
     if i.endswith(".py"):
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/plugs/myplugs/socket/__init__.py
+++ b/jsb/plugs/myplugs/socket/__init__.py
@@ -12,7 +12,7 @@ __all__ = []
 for i in os.listdir(f):
     if i.endswith(".py"):
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:

--- a/jsb/plugs/socket/__init__.py
+++ b/jsb/plugs/socket/__init__.py
@@ -12,7 +12,7 @@ blocklist = ["fish.py", "irccat.py", "geo.py"]
 for i in os.listdir(f):
     if i.endswith(".py") and i not in blocklist:
         __all__.append(i[:-3])
-    elif os.path.isdir(f + os.sep + i) and not i.startswith("."):
+    elif os.path.isdir(f + os.sep + i) and not i.startswith(".") and i != "__pycache__":
         __all__.append(i)
 
 try:


### PR DESCRIPTION
This should suppress these error messages:

```
00:16:20 -=- ERROR    -=- no plugins in jsb.plugs.common.__pycache__ .. define __plugs__ in __init__.py -=- plugins.loadall.118 -=- MainThread
00:16:20 -=- ERROR    -=- no plugins in jsb.plugs.__pycache__ .. define __plugs__ in __init__.py      -=- plugins.loadall.118 -=- MainThread
00:16:20 -=- ERROR    -=- no plugins in jsb.plugs.socket.__pycache__ .. define __plugs__ in __init__.py -=- plugins.loadall.118 -=- MainThread
00:16:20 -=- ERROR    -=- no plugins in jsb.plugs.core.__pycache__ .. define __plugs__ in __init__.py -=- plugins.loadall.118 -=- MainThread
00:16:20 -=- ERROR    -=- no plugins in myplugs.common.__pycache__ .. define __plugs__ in __init__.py -=- plugins.loadall.118 -=- MainThread
00:16:20 -=- ERROR    -=- no plugins in myplugs.__pycache__ .. define __plugs__ in __init__.py        -=- plugins.loadall.118 -=- MainThread
00:16:20 -=- ERROR    -=- no plugins in myplugs.socket.__pycache__ .. define __plugs__ in __init__.py -=- plugins.loadall.118 -=- MainThread
```